### PR TITLE
Disable ADAL cache in MSAL V4 changes

### DIFF
--- a/TokenCacheMigration/CommonCacheAdalV5/Program.cs
+++ b/TokenCacheMigration/CommonCacheAdalV5/Program.cs
@@ -14,6 +14,7 @@ namespace CommonCacheADALV5
     {
         static void Main(string[] args)
         {
+            Console.WriteLine("--------------------------------------------------------------------------");
             Console.WriteLine(Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
             DoIt().Wait();
 
@@ -22,6 +23,7 @@ namespace CommonCacheADALV5
             {
                 Console.ReadLine();
             }
+            Console.WriteLine("--------------------------------------------------------------------------");
         }
 
         static async Task DoIt()

--- a/TokenCacheMigration/CommonCacheAdalv3/Program.cs
+++ b/TokenCacheMigration/CommonCacheAdalv3/Program.cs
@@ -14,6 +14,7 @@ namespace CommonCacheADAL
     {
         static void Main(string[] args)
         {
+            Console.WriteLine("--------------------------------------------------------------------------");
             Console.WriteLine(Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
             DoIt().Wait();
 
@@ -22,6 +23,7 @@ namespace CommonCacheADAL
             {
                 Console.ReadLine();
             }
+            Console.WriteLine("--------------------------------------------------------------------------");
         }
 
         static async Task DoIt()

--- a/TokenCacheMigration/CommonCacheMsalV3/Program.cs
+++ b/TokenCacheMigration/CommonCacheMsalV3/Program.cs
@@ -13,9 +13,16 @@ namespace CommonCacheMsalV3
     {
         static void Main(string[] args)
         {
+            Console.WriteLine("--------------------------------------------------------------------------");
             Console.WriteLine(Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
             DoIt().Wait();
-            Console.ReadLine();
+
+            // Unless ran in a batch, let the user press return to continue
+            if (args.Length == 0)
+            {
+                Console.ReadLine();
+            }
+            Console.WriteLine("--------------------------------------------------------------------------");
         }
 
         static async Task DoIt()

--- a/TokenCacheMigration/CommonCacheMsalV4/Program.cs
+++ b/TokenCacheMigration/CommonCacheMsalV4/Program.cs
@@ -13,17 +13,19 @@ namespace CommonCacheMsalV4
     {
         static void Main(string[] args)
         {
+            Console.WriteLine("--------------------------------------------------------------------------");
             Console.WriteLine(Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
-            DoIt().Wait();
+            DoIt(args.Contains("-disable-legacy-cache")).Wait();
 
             // Unless ran in a batch, let the user press return to continue
             if (args.Length == 0)
             {
                 Console.ReadLine();
             }
+            Console.WriteLine("--------------------------------------------------------------------------");
         }
 
-        static async Task DoIt()
+        static async Task DoIt(bool disableLegacyCache)
         {
             AppCoordinates.AppCoordinates v1App = AppCoordinates.PreRegisteredApps.GetV1App(useInMsal: true);
             string resource = AppCoordinates.PreRegisteredApps.MsGraph;
@@ -35,10 +37,17 @@ namespace CommonCacheMsalV4
 
             AuthenticationResult result;
 
-            IPublicClientApplication app;
-            app = PublicClientApplicationBuilder.Create(v1App.ClientId)
-                                                .WithAuthority(v1App.Authority)
-                                                .Build();
+
+            PublicClientApplicationBuilder builder = PublicClientApplicationBuilder.Create(v1App.ClientId)
+                                                .WithAuthority(v1App.Authority);
+             
+            if (disableLegacyCache)
+            {
+                Console.WriteLine("Disabled legacy cache.");
+                builder.WithLegacyCacheCompatibility(false);
+            }
+                                                
+            IPublicClientApplication app = builder.Build();
             FilesBasedTokenCacheHelper.EnableSerialization(app.UserTokenCache,
                                                            msalCacheFileName,
                                                            adalV3cacheFileName);

--- a/TokenCacheMigration/README.md
+++ b/TokenCacheMigration/README.md
@@ -21,6 +21,17 @@ This solution provides three .NET desktop console applications and one common li
 
 ![image](https://user-images.githubusercontent.com/13203188/45534630-a5e25200-b7b0-11e8-98ca-0e21c3df1176.png)
 
+### Disabling legacy token cache
+MSAL has some internal code specifically to enable the ability to interact with legacy ADAL cache. When MSAL and ADAL are not used side-by-side (therefore the legacy cache is not used), the related legacy cache code is unnecessary. MSAL [4.25.0](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.25.0) adds the ability to disable legacy ADAL cache code and improve cache usage performance. See pull request [#2309](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2309) for performance comparison before and after disabling the legacy cache. Call `.WithLegacyCacheCompatibility(false)` on an application builder like below.
+
+```csharp
+var app = ConfidentialClientApplicationBuilder
+	.Create(clientId)
+	.WithClientSecret(clientSecret)
+	.WithLegacyCacheCompatibility(false)
+	.Build();
+```
+
 ## Getting Started
 
 1. Clone this repository
@@ -47,7 +58,7 @@ This solution provides three .NET desktop console applications and one common li
 - [Token cache serialization](https://aka.ms/adal-net-token-cache-serialization) in ADAL.NET:
   - [legacy](https://aka.ms/adal-net-token-cache-serialization-legacy) token cache serialization (ADAL V3 format)
   - [unified cache](https://aka.ms/adal-net-token-cache-serialization-unified) token cache serialization
-- Token cache serialization in MSAL.NET
+- [Token cache serialization](https://aka.ms/msal-net-token-cache-serialization) in MSAL.NET
 
 ### About ADAL.NET and MSAL.NET
 

--- a/TokenCacheMigration/TestAll-no-prompt.bat
+++ b/TokenCacheMigration/TestAll-no-prompt.bat
@@ -1,31 +1,44 @@
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheAdalV3\bin\Debug\CommonCacheAdalV3.exe -batch
 CommonCacheAdalV5\bin\Debug\CommonCacheAdalV5.exe -batch
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheAdalV3\bin\Debug\CommonCacheAdalV3.exe -batch
 CommonCacheMsalV3\bin\Debug\CommonCacheMsalV3.exe -batch
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheAdalV5\bin\Debug\CommonCacheAdalV5.exe -batch
 CommonCacheAdalV3\bin\Debug\CommonCacheAdalV3.exe -batch
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheAdalV5\bin\Debug\CommonCacheAdalV5.exe -batch
 CommonCacheMsalV3\bin\Debug\CommonCacheMsalV3.exe -batch
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheMsalV3\bin\Debug\CommonCacheMsalV3.exe -batch
 CommonCacheAdalV3\bin\Debug\CommonCacheAdalV3.exe -batch
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheMsalV3\bin\Debug\CommonCacheMsalV3.exe -batch
 CommonCacheAdalV5\bin\Debug\CommonCacheAdalV5.exe -batch
+
+rem Demonstrates disabling legacy ADAL cache in MSAL V4.
+del cacheAdalV3.bin
+del cacheMsal.bin
+CommonCacheMsalV4\bin\Debug\CommonCacheMsalV4.exe -batch
+
+del cacheMsal.bin
+rem When legacy cache is enabled in MSAL, MSAL will use cacheAdalV3.bin to retrieve token.
+CommonCacheMsalV4\bin\Debug\CommonCacheMsalV4.exe -batch
+
+del cacheMsal.bin
+rem When legacy cache is disabled in MSAL and cacheMsal.bin doesn't exist, login UI will be shown.
+CommonCacheMsalV4\bin\Debug\CommonCacheMsalV4.exe -batch -disable-legacy-cache
 
 pause

--- a/TokenCacheMigration/TestAll.bat
+++ b/TokenCacheMigration/TestAll.bat
@@ -1,31 +1,44 @@
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheAdalV3\bin\Debug\CommonCacheAdalV3.exe
 CommonCacheAdalV5\bin\Debug\CommonCacheAdalV5.exe
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheAdalV3\bin\Debug\CommonCacheAdalV3.exe
 CommonCacheMsalV3\bin\Debug\CommonCacheMsalV3.exe
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheAdalV5\bin\Debug\CommonCacheAdalV5.exe
 CommonCacheAdalV3\bin\Debug\CommonCacheAdalV3.exe
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheAdalV5\bin\Debug\CommonCacheAdalV5.exe
 CommonCacheMsalV3\bin\Debug\CommonCacheMsalV3.exe
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheMsalV3\bin\Debug\CommonCacheMsalV3.exe
 CommonCacheAdalV3\bin\Debug\CommonCacheAdalV3.exe
 
 del cacheAdalV3.bin
-del unifiedCache.bin
+del cacheMsal.bin
 CommonCacheMsalV3\bin\Debug\CommonCacheMsalV3.exe
 CommonCacheAdalV5\bin\Debug\CommonCacheAdalV5.exe
+
+rem Demonstrates disabling legacy ADAL cache in MSAL V4.
+del cacheAdalV3.bin
+del cacheMsal.bin
+CommonCacheMsalV4\bin\Debug\CommonCacheMsalV4.exe
+
+del cacheMsal.bin
+rem When legacy cache is enabled in MSAL, MSAL will use cacheAdalV3.bin to retrieve token.
+CommonCacheMsalV4\bin\Debug\CommonCacheMsalV4.exe
+
+del cacheMsal.bin
+rem When legacy cache is disabled in MSAL and cacheMsal.bin doesn't exist, login UI will be shown.
+CommonCacheMsalV4\bin\Debug\CommonCacheMsalV4.exe -disable-legacy-cache
 
 pause


### PR DESCRIPTION
Update README with info about how to disable ADAL cache in MSAL.
Update MSAL V4 sample to accept -disable-adal-cache console arg. 
Update bat files to demonstrate this feature.
Update bat files to delete correct MSAL cache file.