### PR TITLE
Fixing the SQL server timeout for the token cache

### DIFF
--- a/ConfidentialClientTokenCache/Program.cs
+++ b/ConfidentialClientTokenCache/Program.cs
@@ -103,6 +103,12 @@ namespace ConfidentialClientTokenCache
                         options.ConnectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=TestCache;Integrated Security=True;Connect Timeout=30;Encrypt=False;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False";
                         options.SchemaName = "dbo";
                         options.TableName = "TestCache";
+
+                        // You don't want the SQL token cache to be purged before the access token has expired. Usually
+                        // access tokens expire after 1 hours (but this can be changed by token lifetime policies), whereas
+                        // the default sliding expiration for the distributed SQL database is 20 mins. 
+                        // Use a value which is above 60 mins (or the lifetime of a token in case of longer lived tokens)
+                        options.DefaultSlidingExpiration = TimeSpan.FromMinutes(90);
                     });
                     break;
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
The serialized token cache should not be purged before the access token expires (otherwise the user will have to re-sign-in in a web app). However the SQL sliding expiry is 20 mins by default, whereas the token usually expire after 1h

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]

```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
See also https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/pull/457