### PR TITLE
Add missing service  for cosmos cache to work

### DIFF
--- a/ConfidentialClientTokenCache/Program.cs
+++ b/ConfidentialClientTokenCache/Program.cs
@@ -126,6 +126,7 @@ namespace ConfidentialClientTokenCache
                 case CacheImplementationDemo.CosmosDb:
                     // Redis token cache
                     // Requires to reference Microsoft.Extensions.Caching.Cosmos (preview)
+                    services.AddDistributedTokenCaches();
                     services.AddCosmosCache((CosmosCacheOptions cacheOptions) =>
                     {
                         cacheOptions.ContainerName = Configuration["CosmosCacheContainer"];


### PR DESCRIPTION


## Purpose
services.AddDistributedTokenCaches() is required. 
When not present, I get {"No service for type 'Microsoft.Identity.Web.TokenCacheProviders.IMsalTokenCacheProvider' has been registered."}

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->